### PR TITLE
Fix CSS

### DIFF
--- a/book/block.css
+++ b/book/block.css
@@ -8,4 +8,5 @@
 	padding: 2px 8px;
 	font-size: small;
 	line-height: inherit;
+	margin-bottom: 0px;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gitbook-plugin-codeblock-filename",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"author": "fukuo",
 	"description": "Add to Filename in Codeblock",
 	"main": "index.js",


### PR DESCRIPTION
In gitbook 2.0 `p` elements have a fixed bottom margin of 16px that breaks this plugin. This pull request fixes it.
