### PR TITLE
Update to work with GitBook 3.2.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ module.exports = {
 
 		// 独自フォーマットからfilenameタグを生成
 		"page": function(page) {
-			var regixAll = /(<p>!FILENAME\s+([\S].+)<\/p>)<pre>[\s\S]*?(<\/pre>)/g;
-			var regix = /(<p>!FILENAME\s+([\S].+)<\/p>)<pre>[\s\S]*?(<\/pre>)/;
+			var regixAll = /(<p>!FILENAME\s+([\S].+)<\/p>)\s*<pre>[\s\S]*?(<\/pre>)/g;
+			var regix = /(<p>!FILENAME\s+([\S].+)<\/p>)\s*<pre>[\s\S]*?(<\/pre>)/;
 			var replacer = function(filename){
 				return '<div><p class="code-filename">' + filename + '</p></div>';
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gitbook-plugin-codeblock-filename",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"author": "fukuo",
 	"description": "Add to Filename in Codeblock",
 	"main": "index.js",


### PR DESCRIPTION
Fixes #4. This works with 3.2.2 as well as the previous versions. 3.2.2 started putting a newline before `<pre>`.